### PR TITLE
Update: moesifpythonrequest library dependency to 0.1.8

### DIFF
--- a/moesifdjango/middleware.py
+++ b/moesifdjango/middleware.py
@@ -209,10 +209,10 @@ class moesif_middleware:
             except:
                 if self.DEBUG:
                     print("could not json parse, so base64 encode")
-                rsp_body = base64.standard_b64encode(response.content)
+                rsp_body = base64.standard_b64encode(response.content).decode()
                 rsp_body_transfer_encoding = 'base64'
                 if self.DEBUG:
-                    print("base64 encoded body: " + rsp_body)
+                    print("base64 encoded body: " + str(rsp_body))
 
         rsp_time = timezone.now()
 

--- a/moesifdjango/middleware_pre19.py
+++ b/moesifdjango/middleware_pre19.py
@@ -187,10 +187,10 @@ class MoesifMiddlewarePre19(object):
             except:
                 if self.DEBUG:
                     print("could not json parse, so base64 encode")
-                rsp_body = base64.standard_b64encode(response.content)
+                rsp_body = base64.standard_b64encode(response.content).decode()
                 rsp_body_transfer_encoding = 'base64'
                 if self.DEBUG:
-                    print("base64 encoded body: " + rsp_body)
+                    print("base64 encoded body: " + str(rsp_body))
 
 
         rsp_time = timezone.now()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ nose==1.3.7
 isodatetimehandler==1.0.2
 moesifapi==1.2.5
 celery==4.1.0
-moesifpythonrequest==0.1.7
+moesifpythonrequest==0.1.8

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.5.4',
+    version='1.5.5',
 
     description='Moesif Middleware for Python Django',
     long_description=long_description,


### PR DESCRIPTION
Update: moesifpythonrequest library dependency to 0.1.8
Fix: Encoding a base64 string for Python3
Bump version to 1.5.5