### PR TITLE
Refactor: Avoid passing scheduler logging messafe to ancestor loggers

### DIFF
--- a/moesifdjango/tasks.py
+++ b/moesifdjango/tasks.py
@@ -117,9 +117,10 @@ if settings.MOESIF_MIDDLEWARE.get('USE_CELERY', False):
         try:
             from apscheduler.schedulers.background import BackgroundScheduler
             from apscheduler.triggers.interval import IntervalTrigger
-            import atexit
             from kombu import Connection
             from kombu.exceptions import ChannelError
+            import atexit
+            import logging
 
             scheduler = BackgroundScheduler(daemon=True)
             scheduler.start()
@@ -133,6 +134,9 @@ if settings.MOESIF_MIDDLEWARE.get('USE_CELERY', False):
                     id='moesif_events_batch_job',
                     name='Schedule events batch job every 5 second',
                     replace_existing=True)
+
+                # Avoid passing logging message to the ancestor loggers
+                logging.getLogger('apscheduler.executors.default').propagate = False
 
                 # Exit handler when exiting the app
                 atexit.register(lambda: exit_handler(moesif_events_queue, scheduler))

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.7.6',
+    version='1.7.7',
 
     description='Moesif Middleware for Python Django',
     long_description=long_description,


### PR DESCRIPTION
Refactor: Avoid passing scheduler logging messafe to ancestor loggers
Bump version to 1.7.7