### PR TITLE
[1/2] add moesifapi install requires with >= 1.4.0

### DIFF
--- a/moesifdjango/middleware.py
+++ b/moesifdjango/middleware.py
@@ -51,7 +51,7 @@ class moesif_middleware:
         # below comment for setting moesif base_uri to a test server.
         if self.middleware_settings.get('LOCAL_DEBUG', False):
             Configuration.BASE_URI = self.get_configuration_uri(self.middleware_settings, 'BASE_URI', 'LOCAL_MOESIF_BASEURL')
-        Configuration.version = 'moesifdjango-python/2.1.4'
+        Configuration.version = 'moesifdjango-python/2.1.5'
         if settings.MOESIF_MIDDLEWARE.get('CAPTURE_OUTGOING_REQUESTS', False):
             try:
                 if self.DEBUG:

--- a/moesifdjango/middleware_pre19.py
+++ b/moesifdjango/middleware_pre19.py
@@ -45,7 +45,7 @@ class MoesifMiddlewarePre19(object):
         # below comment for setting moesif base_uri to a test server.
         if self.middleware_settings.get('LOCAL_DEBUG', False):
             Configuration.BASE_URI = self.get_configuration_uri(self.middleware_settings, 'BASE_URI', 'LOCAL_MOESIF_BASEURL')
-        Configuration.version = 'moesifdjango-python/2.1.4'
+        Configuration.version = 'moesifdjango-python/2.1.5'
         if settings.MOESIF_MIDDLEWARE.get('CAPTURE_OUTGOING_REQUESTS', False):
             try:
                 if self.DEBUG:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='2.1.4',
+    version='2.1.5',
 
     description='Moesif Middleware for Python Django',
     long_description=long_description,
@@ -82,7 +82,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['requests', 'jsonpickle', 'python-dateutil', 'isodatetimehandler', 'moesifapi',
+    install_requires=['requests', 'jsonpickle', 'python-dateutil', 'isodatetimehandler', 'moesifapi>=1.4.0',
                       'moesifpythonrequest', 'apscheduler', 'nose'],
 
     # List additional groups of dependencies here (e.g. development

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=['requests', 'jsonpickle', 'python-dateutil', 'isodatetimehandler', 'moesifapi>=1.4.0',
-                      'moesifpythonrequest', 'apscheduler', 'nose'],
+                      'moesifpythonrequest>=0.2.0', 'apscheduler', 'nose'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Related PR: [2/2] https://github.com/Moesif/moesifdjangoexample/pull/30