### PR TITLE
Log cleanup

### DIFF
--- a/moesifdjango/job_scheduler.py
+++ b/moesifdjango/job_scheduler.py
@@ -49,7 +49,6 @@ class JobScheduler:
 
 
     def batch_events(self, api_client, moesif_events_queue, debug, batch_size):
-        print("Starting batch events job")
         batch_events = []
         try:
             while not moesif_events_queue.empty():

--- a/moesifdjango/job_scheduler.py
+++ b/moesifdjango/job_scheduler.py
@@ -65,12 +65,10 @@ class JobScheduler:
                 # Set the last time event job ran after sending events
                 batch_send_time = datetime.utcnow()
                 delta = batch_send_time - req_time
-                if debug and delta.total_seconds() > 0:
+                if debug and delta.total_seconds() > 60:
                     print("Warning: It took %s seconds to send events to Moesif. req.time=%s now=%s"%(delta.total_seconds(), req_time, batch_send_time))
                 return batch_response_config_etag, batch_response_rules_etag, batch_send_time
             else:
-                if debug:
-                    print("No events to send")
                 # Set the last time event job ran but no message to read from the queue
                 return None, None, datetime.utcnow()
         except Exception as e:

--- a/moesifdjango/middleware.py
+++ b/moesifdjango/middleware.py
@@ -145,6 +145,7 @@ class moesif_middleware:
             if not self.scheduler.get_jobs():
                 self.scheduler.add_listener(self.event_listener, EVENT_JOB_EXECUTED | EVENT_JOB_ERROR)
                 self.scheduler.start()
+                print("Starting batch events job")
                 self.scheduler.add_job(
                     func=lambda: self.job_scheduler.batch_events(self.api_client, self.mo_events_queue, self.DEBUG,
                                                                  self.event_batch_size),


### PR DESCRIPTION
Fix 0s instead of 60s threshold for delay alert and remove log message in default condition that there are no events
Fix start job log message in wrong place.  It's actually inside the batch event function which is run repeatedly instead of where the job gets started, and it should not appear more than once in the logs
https://www.pivotaltracker.com/story/show/185544139/comments/237714998